### PR TITLE
Rename `matchPattern` field name to `separatorPattern`

### DIFF
--- a/src/main/resources/uischema/delete.json
+++ b/src/main/resources/uischema/delete.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/get.json
+++ b/src/main/resources/uischema/get.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/head.json
+++ b/src/main/resources/uischema/head.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/options.json
+++ b/src/main/resources/uischema/options.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/patch.json
+++ b/src/main/resources/uischema/patch.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/post.json
+++ b/src/main/resources/uischema/post.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="

--- a/src/main/resources/uischema/put.json
+++ b/src/main/resources/uischema/put.json
@@ -39,7 +39,7 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "Enter the relative path for the specific API endpoint, appended to the base URL.",
-                    "matchPattern": "([^?&=]+)=([^&]+)",
+                    "separatorPattern": "([^?&=]+)=([^&]+)",
                     "initialSeparator": "?",
                     "secondarySeparator": "&",
                     "keyValueSeparator": "="


### PR DESCRIPTION
## Purpose
For better readability field is renamed. 