### PR TITLE
Add inline expression support for payload field

### DIFF
--- a/src/main/java/org/wso2/carbon/http/connector/RestURLBuilder.java
+++ b/src/main/java/org/wso2/carbon/http/connector/RestURLBuilder.java
@@ -144,6 +144,11 @@ public class RestURLBuilder extends AbstractConnector {
 
         if (StringUtils.isNotEmpty(requestBodyType)) {
             org.apache.axis2.context.MessageContext axis2MessageContext = ((Axis2MessageContext)messageContext).getAxis2MessageContext();
+            try {
+                requestBody = InlineExpressionUtil.processInLineSynapseExpressionTemplate(messageContext, requestBody);
+            } catch (JaxenException e) {
+                handleException("Error while processing request body", messageContext);
+            }
             if (requestBodyType.equals(XML_TYPE)) {
                 try {
                     requestBody = "<pfPadding>" + requestBody + "</pfPadding>";
@@ -155,13 +160,13 @@ public class RestURLBuilder extends AbstractConnector {
                         axis2MessageContext.getEnvelope().getBody().addChild(omXML.getFirstElement());
                     }
                 } catch (XMLStreamException var9) {
-                    this.handleException("Error creating SOAP Envelope from source " + requestBody, messageContext);
+                    handleException("Error creating SOAP Envelope from source " + requestBody, messageContext);
                 }
             } else if (requestBodyType.equals(JSON_TYPE)) {
                 try {
                     JsonUtil.getNewJsonPayload(axis2MessageContext, requestBody, true, true);
                 } catch (AxisFault var8) {
-                    this.handleException("Error creating JSON Payload from source " + requestBody, messageContext);
+                    handleException("Error creating JSON Payload from source " + requestBody, messageContext);
                 }
             } else if (requestBodyType.equals(TEXT_TYPE)) {
                 JsonUtil.removeJsonPayload(axis2MessageContext);

--- a/src/main/resources/uischema/post.json
+++ b/src/main/resources/uischema/post.json
@@ -98,7 +98,7 @@
                   "value": {
                     "name": "requestBodyJson",
                     "displayName": "Request Body",
-                    "inputType": "stringOrExpression",
+                    "inputType": "expressionTextArea",
                     "defaultValue": "${payload}",
                     "required": "false",
                     "helpTip": "",
@@ -114,7 +114,7 @@
                   "value": {
                     "name": "requestBodyXml",
                     "displayName": "Request Body",
-                    "inputType": "stringOrExpression",
+                    "inputType": "expressionTextArea",
                     "defaultValue": "${xpath('$body/node()')}",
                     "required": "true",
                     "helpTip": "",
@@ -130,7 +130,7 @@
                   "value": {
                     "name": "requestBodyText",
                     "displayName": "Request Body",
-                    "inputType": "stringOrExpression",
+                    "inputType": "expressionTextArea",
                     "defaultValue": "${xpath('$body/node()')}",
                     "required": "false",
                     "helpTip": "",


### PR DESCRIPTION
## Purpose
Some operations support adding a payload when defining an operation. This PR introduces the ability to provide an inline expression (text containing expressions) for the payload field.