### PR TITLE
Handle new input format for headers

### DIFF
--- a/src/main/java/org/wso2/carbon/http/connector/RestURLBuilder.java
+++ b/src/main/java/org/wso2/carbon/http/connector/RestURLBuilder.java
@@ -35,6 +35,7 @@ import org.apache.synapse.util.AXIOMUtils;
 import org.apache.synapse.util.InlineExpressionUtil;
 import org.jaxen.JaxenException;
 import org.json.JSONArray;
+import org.json.JSONObject;
 import org.wso2.carbon.connector.core.AbstractConnector;
 
 import java.io.StringReader;
@@ -288,14 +289,30 @@ public class RestURLBuilder extends AbstractConnector {
                 if (headersArray.length() > 0) {
                     Utils.initializeTransportHeaders(messageContext);
                     Object transportHeaders = Utils.getTransportHeaders(messageContext);
-                    for (int i = 0; i < headersArray.length(); i++) {
-                        JSONArray headersItem = headersArray.getJSONArray(i);
-                        if (headersItem.length() == 2) {
-                            String headerName = headersItem.getString(0).trim();
-                            String headerValue = headersItem.getString(1).trim();
-                            if (transportHeaders instanceof Map) {
-                                Map transportHeadersMap = (Map) transportHeaders;
-                                transportHeadersMap.put(headerName, headerValue);
+                    if (transportHeaders instanceof Map) {
+                        Map transportHeadersMap = (Map) transportHeaders;
+                        for (int i = 0; i < headersArray.length(); i++) {
+                            Object headersItem = headersArray.get(i);
+                            if (headersItem instanceof JSONArray) {
+                                JSONArray headersArrayItem = (JSONArray) headersItem;
+                                if (headersArrayItem.length() == 2) {
+                                    String headerName = headersArrayItem.getString(0).trim();
+                                    String headerValue = headersArrayItem.getString(1).trim();
+                                    if (StringUtils.isNotEmpty(headerName)) {
+                                        transportHeadersMap.put(headerName, headerValue);
+                                    }
+                                }
+                            } else if (headersItem instanceof JSONObject) {
+                                JSONObject headersObjectItem = (JSONObject) headersItem;
+                                if (headersObjectItem.keys().hasNext()) {
+                                    String headerName = String.valueOf(headersObjectItem.keys().next());
+                                    String headerValue = headersObjectItem.getString(headerName);
+                                    String trimmedHeaderName = headerName.trim();
+                                    String trimmedHeaderValue = headerValue.trim();
+                                    if (StringUtils.isNotEmpty(trimmedHeaderName)) {
+                                        transportHeadersMap.put(trimmedHeaderName, trimmedHeaderValue);
+                                    }
+                                }
                             }
                         }
                     }

--- a/src/test/java/org/wso2/carbon/http/connector/TestRestURLBuilder.java
+++ b/src/test/java/org/wso2/carbon/http/connector/TestRestURLBuilder.java
@@ -121,6 +121,85 @@ public class TestRestURLBuilder {
     }
 
     @Test
+    public void testAddNewFormatHeaders() throws AxisFault {
+
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.HEADERS_IDENTIFIER, "[{\"Content-Type\": \"application/xml\"}, {\"Accept\": \"application/json\"}]");
+        restURLBuilder.connect(messageContext);
+        Axis2MessageContext axis2MessageContext = (Axis2MessageContext) messageContext;
+        Object transportHeaders = axis2MessageContext.getAxis2MessageContext().getProperty("TRANSPORT_HEADERS");
+        assertNotNull(transportHeaders);
+        Map transportHeadersMap = (Map) transportHeaders;
+        String actualHeader1 = (String) transportHeadersMap.get("Content-Type");
+        String actualHeader2 = (String) transportHeadersMap.get("Accept");
+        assertEquals("application/xml", actualHeader1);
+        assertEquals("application/json", actualHeader2);
+    }
+
+    @Test
+    public void testAddHeadersWithAdditionalSpaces() throws AxisFault {
+
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.HEADERS_IDENTIFIER, "[{\"Content-Type \": \" application/xml \"}, [\" Accept \", \" application/json \"]]");
+        restURLBuilder.connect(messageContext);
+        Axis2MessageContext axis2MessageContext = (Axis2MessageContext) messageContext;
+        Object transportHeaders = axis2MessageContext.getAxis2MessageContext().getProperty("TRANSPORT_HEADERS");
+        assertNotNull(transportHeaders);
+        Map transportHeadersMap = (Map) transportHeaders;
+        String actualHeader1 = (String) transportHeadersMap.get("Content-Type");
+        String actualHeader2 = (String) transportHeadersMap.get("Accept");
+        assertEquals("application/xml", actualHeader1);
+        assertEquals("application/json", actualHeader2);
+    }
+
+    @Test
+    public void testAddHeadersWithEmptyKeys() throws AxisFault {
+
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.HEADERS_IDENTIFIER, "[[\"\", \"application/xml\"], {\"  \": \"application/json\"}]");
+        restURLBuilder.connect(messageContext);
+        Axis2MessageContext axis2MessageContext = (Axis2MessageContext) messageContext;
+        Object transportHeaders = axis2MessageContext.getAxis2MessageContext().getProperty("TRANSPORT_HEADERS");
+        assertNotNull(transportHeaders);
+        Map transportHeadersMap = (Map) transportHeaders;
+        assertTrue(transportHeadersMap.isEmpty());
+    }
+
+    @Test
+    public void testAddHeadersWithEmptyValues() throws AxisFault {
+
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.HEADERS_IDENTIFIER, "[[\"Content-Type\", \" \"], {\"Accept\": \"\"}]");
+        restURLBuilder.connect(messageContext);
+        Axis2MessageContext axis2MessageContext = (Axis2MessageContext) messageContext;
+        Object transportHeaders = axis2MessageContext.getAxis2MessageContext().getProperty("TRANSPORT_HEADERS");
+        assertNotNull(transportHeaders);
+        Map transportHeadersMap = (Map) transportHeaders;
+        String actualHeader1 = (String) transportHeadersMap.get("Content-Type");
+        String actualHeader2 = (String) transportHeadersMap.get("Accept");
+        assertEquals("", actualHeader1);
+        assertEquals("", actualHeader2);
+    }
+
+    @Test
+    public void testAddMultipleEmptyHeaders() throws AxisFault {
+
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.HEADERS_IDENTIFIER, "[[], {}]");
+        restURLBuilder.connect(messageContext);
+        Axis2MessageContext axis2MessageContext = (Axis2MessageContext) messageContext;
+        Object transportHeaders = axis2MessageContext.getAxis2MessageContext().getProperty("TRANSPORT_HEADERS");
+        assertNotNull(transportHeaders);
+        Map transportHeadersMap = (Map) transportHeaders;
+        assertTrue(transportHeadersMap.isEmpty());
+    }
+
+    @Test
     public void testProcessJsonRequestBody() throws AxisFault {
 
         String expectedBody = "<jsonObject><id>7</id><name>Peoples</name></jsonObject>";


### PR DESCRIPTION
## Purpose
As XML structure for tables in connectors was updated with [this](https://github.com/wso2/mi-language-server/pull/417). Handling headers in the HTTP connector is updated to handle both following formats: 
* `[["key1", "value1"], ["key2", "value2"]]`
* `[{"key1": "value1"}, {"key2": "value2"}]` 

Along with this, a change to avoid adding any header with a empty name is introduced as well. 