### PR TITLE
Update handling concatenation of base path in connection and relative path in the operation

### DIFF
--- a/src/main/java/org/wso2/carbon/http/connector/Constants.java
+++ b/src/main/java/org/wso2/carbon/http/connector/Constants.java
@@ -22,6 +22,7 @@ import javax.xml.namespace.QName;
 
 public class Constants {
 
+    public static final String BASE_PATH_IDENTIFIER = "HTTP_CONN_BASE_PATH";
     public static final String RELATIVE_PATH_IDENTIFIER = "HTTP_CONN_RELATIVE_PATH";
     public static final String HEADERS_IDENTIFIER = "HTTP_CONN_HEADERS";
     public static final String REQUEST_BODY_TYPE_IDENTIFIER = "HTTP_CONN_REQUEST_BODY_TYPE";
@@ -32,7 +33,9 @@ public class Constants {
     public static final String JSON_TYPE = "JSON";
     public static final String XML_TYPE = "XML";
     public static final String TEXT_TYPE = "TEXT";
+    public static final String URL_BASE =  "uri.var.base";
     public static final String URL_PATH = "uri.var.path";
+    public static final String URL_QUERY = "uri.var.query";
     public static final String SINGLE_QUOTE = "\'";
     public static final String XML_CONTENT_TYPE = "application/xml";
     public static final String JSON_CONTENT_TYPE = "application/json";
@@ -40,4 +43,5 @@ public class Constants {
     public static final String SOAP11_CONTENT_TYPE = "text/xml";
     public static final String SOAP12_CONTENT_TYPE = "application/soap+xml";
     public static final String EMPTY_LIST = "[]";
+    public static final String FORWARD_SLASH = "/";
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -24,6 +24,6 @@
     <sequence>
         <property name="httpConnectorConnectionName" expression="$func:name"/>
         <property name="httpConnectorConnectionEndpointName" expression="concat($func:name, '_INTERNAL_ENDPOINT_REFERENCE')"/>
-        <property name="uri.var.base" expression="$func:baseUrl"/>
+        <property name="HTTP_CONN_BASE_PATH" expression="$func:baseUrl"/>
     </sequence>
 </template>

--- a/src/main/resources/functions/delete.xml
+++ b/src/main/resources/functions/delete.xml
@@ -68,6 +68,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
 

--- a/src/main/resources/functions/get.xml
+++ b/src/main/resources/functions/get.xml
@@ -68,6 +68,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
 

--- a/src/main/resources/functions/head.xml
+++ b/src/main/resources/functions/head.xml
@@ -76,6 +76,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
         <property name="HTTP_CONN_REQUEST_BODY_TYPE" action="remove"/>

--- a/src/main/resources/functions/options.xml
+++ b/src/main/resources/functions/options.xml
@@ -76,6 +76,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
         <property name="HTTP_CONN_REQUEST_BODY_TYPE" action="remove"/>

--- a/src/main/resources/functions/patch.xml
+++ b/src/main/resources/functions/patch.xml
@@ -76,6 +76,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
         <property name="HTTP_CONN_REQUEST_BODY_TYPE" action="remove"/>

--- a/src/main/resources/functions/post.xml
+++ b/src/main/resources/functions/post.xml
@@ -76,6 +76,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
         <property name="HTTP_CONN_REQUEST_BODY_TYPE" action="remove"/>

--- a/src/main/resources/functions/put.xml
+++ b/src/main/resources/functions/put.xml
@@ -76,6 +76,7 @@
         <property name="uri.var.base" action="remove"/>
         <property name="uri.var.path" action="remove"/>
         <property name="uri.var.query" action="remove"/>
+        <property name="HTTP_CONN_BASE_PATH" action="remove"/>
         <property name="HTTP_CONN_RELATIVE_PATH" action="remove"/>
         <property name="HTTP_CONN_HEADERS" action="remove"/>
         <property name="HTTP_CONN_REQUEST_BODY_TYPE" action="remove"/>

--- a/src/test/java/org/wso2/carbon/http/connector/TestRestURLBuilder.java
+++ b/src/test/java/org/wso2/carbon/http/connector/TestRestURLBuilder.java
@@ -55,17 +55,41 @@ import static org.junit.Assert.assertTrue;
 public class TestRestURLBuilder {
 
     @Test
-    public void testProcessUrlPath() throws AxisFault {
+    public void testProcessUrl() throws AxisFault {
 
+        String basePath = "https://example.com";
         String relativePath = "/books/${vars.id}/author/${vars.name}";
         RestURLBuilder restURLBuilder = new RestURLBuilder();
         MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.BASE_PATH_IDENTIFIER, basePath);
         messageContext.setProperty(Constants.RELATIVE_PATH_IDENTIFIER, relativePath);
         messageContext.setVariable("id", 1);
         messageContext.setVariable("name", "John");
         restURLBuilder.connect(messageContext);
-        String expectedUrlPath = (String) messageContext.getProperty(Constants.URL_PATH);
-        assertEquals(expectedUrlPath, "/books/1/author/John");
+        String actualBasePath = (String) messageContext.getProperty(Constants.URL_BASE);
+        String actualRelativePath = (String) messageContext.getProperty(Constants.URL_PATH);
+        String actualQuery = (String) messageContext.getProperty(Constants.URL_QUERY);
+        assertEquals("https://example.com", actualBasePath);
+        assertEquals("/books/1/author/John", actualRelativePath);
+        assertEquals("", actualQuery);
+    }
+
+    @Test
+    public void testProcessUrlBasePathRelativePathConcatenation() throws AxisFault {
+        String basePath = "https://example.com/api/";
+        String relativePath = "/v1/resources/${vars.resourceId}";
+        RestURLBuilder restURLBuilder = new RestURLBuilder();
+        MessageContext messageContext = createMessageContext();
+        messageContext.setProperty(Constants.BASE_PATH_IDENTIFIER, basePath);
+        messageContext.setProperty(Constants.RELATIVE_PATH_IDENTIFIER, relativePath);
+        messageContext.setVariable("resourceId", 42);
+        restURLBuilder.connect(messageContext);
+        String actualBasePath = (String) messageContext.getProperty(Constants.URL_BASE);
+        String actualRelativePath = (String) messageContext.getProperty(Constants.URL_PATH);
+        String actualQuery = (String) messageContext.getProperty(Constants.URL_QUERY);
+        assertEquals("https://example.com/api", actualBasePath);
+        assertEquals("/v1/resources/42", actualRelativePath);
+        assertEquals("", actualQuery);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
Currently the base path in the connection and the relative path in the operation is directly concatenated to get the complete URL. This raises the issue https://github.com/wso2/product-micro-integrator/issues/4189. This will handle it by removing a forward slash if there is one in the end of the base URL and adding a forward slash in the beginning of the relative path if there isn't one already. 