### PR TITLE
Add `APPEND_ARTIFACT_IDENTIFIER` property

### DIFF
--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -25,5 +25,6 @@
         <property name="httpConnectorConnectionName" expression="$func:name"/>
         <property name="httpConnectorConnectionEndpointName" expression="concat($func:name, '_INTERNAL_ENDPOINT_REFERENCE')"/>
         <property name="HTTP_CONN_BASE_PATH" expression="$func:baseUrl"/>
+        <property name="APPEND_ARTIFACT_IDENTIFIER" value="true" type="BOOLEAN" />
     </sequence>
 </template>


### PR DESCRIPTION
## Purpose

Since the connector use resolving endpoints, we need to add this property (`APPEND_ARTIFACT_IDENTIFIER`), to make sure the fully qualified names are used when versioned deployment is enabled.